### PR TITLE
Refactor pawscp for instanceinfo

### DIFF
--- a/paws
+++ b/paws
@@ -337,8 +337,8 @@ getPathToKey()
             RETVAL="${COMMON_KEY_DIR}/devops.center/keys/${keyName}.pem"
         elif [[ -f "${COMMON_KEY_DIR}/${PROFILE}/devops.center/keys/${keyName}.pem" ]]; then
             RETVAL="${COMMON_KEY_DIR}/${PROFILE}/devops.center/keys/${keyName}.pem"
-        elif [[ -f ~/.ssh/devops.center/${keyName}.pem ]]; then
-            RETVAL="~/.ssh/devops.center/${keyName}.pem"
+        elif [[ -f ${HOME}/.ssh/devops.center/${keyName}.pem ]]; then
+            RETVAL="${HOME}/.ssh/devops.center/${keyName}.pem"
         else
             RETVAL="${COMMON_KEY_DIR}/${PROFILE}/keys/${keyName}.pem"
         fi
@@ -653,7 +653,7 @@ while [[ ${i} -lt ${numItems} ]]; do
 
             jumpServerPathToKey=''
             getPathToKey ${jumpServerKey} jumpServerPathToKey
-            jumpServerCommand="ProxyCommand \"ssh -i ${jumpServerPathToKey} -W %h:%p -p ${jumpServerPort} ${jumpServerLogin}@${jumpServerHost}\""
+            jumpServerCommand="ProxyCommand ssh -i ${jumpServerPathToKey} -W %h:%p -p ${jumpServerPort} ${jumpServerLogin}@${jumpServerHost}"
             echo " ${jumpServerCommand}" >> ${TMP_CONFIG}
         fi
         echo >> ${TMP_CONFIG}

--- a/pawscp
+++ b/pawscp
@@ -154,17 +154,27 @@ myscp()
     local SECOND_FILE=$3
     local SECOND_HOST=$4
 
+    QUIET_OPTION=""
+    if [[ ${PRINT_OUTPUT} == 'false' ]]; then
+        QUIET_OPTION=" -q "
+    fi
     if [[ -z ${FIRST_HOST} ]]; then
         if [[ ${DO_NOT_RUN} == 'true' ]]; then
             echo "scp -F ${TMP_CONFIG} ${FIRST_FILE} ${SECOND_HOST}:${SECOND_FILE}"
         else
-            scp -q -F ${TMP_CONFIG} "${FIRST_FILE}" "${SECOND_HOST}:${SECOND_FILE}"
+            if [[ ${PRINT_OUTPUT} == 'true' ]]; then
+                echo "transferring: ${FIRST_FILE} => $SECOND_HOST:$SECOND_FILE"
+            fi
+            scp ${QUIET_OPTION} -F ${TMP_CONFIG} "${FIRST_FILE}" "${SECOND_HOST}:${SECOND_FILE}"
         fi
     else
         if [[ ${DO_NOT_RUN} == 'true' ]]; then
             echo "scp -F ${TMP_CONFIG} ${FIRST_HOST}:${FIRST_FILE} ${SECOND_FILE}"
         else
-            scp -q -F ${TMP_CONFIG} "${FIRST_HOST}:${FIRST_FILE}" "${SECOND_FILE}"
+            if [[ ${PRINT_OUTPUT} == 'true' ]]; then
+                echo "transferring: ${FIRST_FILE} => $SECOND_HOST:$SECOND_FILE"
+            fi
+            scp ${QUIET_OPTION} -F ${TMP_CONFIG} "${FIRST_HOST}:${FIRST_FILE}" "${SECOND_FILE}"
         fi
     fi
 }
@@ -505,8 +515,7 @@ createSSHConfigFile()
 #---- start of main ------------------------------------------------------------
 
 NEW_CMD_LINE=''
-APPNAME=''
-WORKSPACENAME=''
+PRINT_OUTPUT='true'
 while [[ $# -gt 0 ]]; do
     case $1 in
         -p ) shift
@@ -518,31 +527,8 @@ while [[ $# -gt 0 ]]; do
         -t ) shift
                 TAG=$1
                 ;;
-        -w ) shift
-                HOSTS=$1
-	            ;;
-        -l ) LIST_NAMES='true'
-	            ;;
-        -c ) if [[ $# -eq 2 ]]; then
-                shift
-	            HOST=$1
-	        else
-	            CONNECT='true'
-	        fi
-                 ;;
-        -L ) LIST_NAMES='true'
-             LIST_ALL='true'
-                 ;;
-        -a | --appName) shift
-             APPNAME=$1
-             dcDEFAULT_APP_NAME=$1
-             NEW_CMD_LINE="${NEW_CMD_LINE} --appName $APPNAME"
-                 ;;
-        --workspaceName) shift
-             NEW_CMD_LINE="${NEW_CMD_LINE} --workspaceName $1"
-                 ;;
-        -e | --env) shift
-             NEW_CMD_LINE="${NEW_CMD_LINE} --env $1"
+        -q | --quiet )
+             PRINT_OUTPUT='false'
                  ;;
         --test )
              DO_NOT_RUN='true'
@@ -553,10 +539,6 @@ while [[ $# -gt 0 ]]; do
  [!-]* ) if [[ $# -eq 2 ]]; then
              FIRST_ARG=$1
              SECOND_ARG=$2
-	     elif ! [[ -z "$HOST" ]]; then
-             echo -e "Too many/few of the 1 required parameters.\n"
-             usage
-             exit 1
          fi
                  ;;
 #         * ) echo -e "Unrecognized input.\n"

--- a/pawscp
+++ b/pawscp
@@ -488,7 +488,7 @@ createSSHConfigFile()
 
             jumpServerPathToKey=''
             getPathToKey ${jumpServerKey} jumpServerPathToKey
-            jumpServerCommand="ProxyCommand "ssh -i ${jumpServerPathToKey} -W %h:%p -p ${jumpServerPort} ${jumpServerLogin}@${jumpServerHost}"
+            jumpServerCommand="ProxyCommand ssh -i ${jumpServerPathToKey} -W %h:%p -p ${jumpServerPort} ${jumpServerLogin}@${jumpServerHost}"
             echo " ${jumpServerCommand}" >> ${TMP_CONFIG}
         fi
         echo >> ${TMP_CONFIG}

--- a/pawscp
+++ b/pawscp
@@ -168,7 +168,7 @@ myscp()
             if [[ ${PRINT_OUTPUT} == 'true' ]]; then
                 echo "transferring: ${FIRST_FILE} => $SECOND_HOST:$SECOND_FILE"
             fi
-            scp ${QUIET_OPTION} -F ${TMP_CONFIG} "${FIRST_FILE}" "${SECOND_HOST}:${SECOND_FILE}"
+            scp ${QUIET_OPTION} -F ${TMP_CONFIG} ${FIRST_FILE} ${SECOND_HOST}:${SECOND_FILE}
         fi
     else
         if [[ ${DO_NOT_RUN} == 'true' ]]; then
@@ -177,7 +177,7 @@ myscp()
             if [[ ${PRINT_OUTPUT} == 'true' ]]; then
                 echo "transferring: ${FIRST_FILE} => $SECOND_HOST:$SECOND_FILE"
             fi
-            scp ${QUIET_OPTION} -F ${TMP_CONFIG} "${FIRST_HOST}:${FIRST_FILE}" "${SECOND_FILE}"
+            scp ${QUIET_OPTION} -F ${TMP_CONFIG} ${FIRST_HOST}:${FIRST_FILE} ${SECOND_FILE}
         fi
     fi
 }

--- a/pawscp
+++ b/pawscp
@@ -63,6 +63,25 @@ if [[ -z $1 ]]; then
     exit 1
 fi
 
+
+#---  FUNCTION  ----------------------------------------------------------------
+#          NAME:  getValueFromSettings
+#   DESCRIPTION:  will get the value of the key passed in from ~/.dcConfig/settings
+#    PARAMETERS:  the key to look for
+#       RETURNS:  the value of the key once it's found
+#-------------------------------------------------------------------------------
+getValueFromSettings()
+{
+    keyToFind=$1
+    aKeyValue=$(grep "^${keyToFind}" ~/.dcConfig/settings)
+    justTheValue=${aKeyValue#*=}
+    # remove any double quotes around the value
+    var1=${justTheValue#*\"}
+    unquotedVar=${var1%\"}
+    echo "${unquotedVar#*=}"
+}	# ----------  end of function getValueFromSettings  ----------
+
+
 #-------------------------------------------------------------------------------
 # handle arguments: need conditionals for appropriate number of arguments/options
 #-------------------------------------------------------------------------------
@@ -105,14 +124,19 @@ doTheCopy()
 #        echo "The first file will be copied to all instances into directory ${SECOND_FILE}"
 #    fi
 
-    for theItem in "${NEW_SSH_CONFIG_VARS[@]}"
-    do
-        IFS=$','; configItemList=($theItem); unset IFS;
+    i=0
+    numItems=$(echo ${DESCRIBE_ALL} | jq -c 'length')
+    while [[ ${i} -lt ${numItems} ]]; do
+        hostName=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].InstanceName")
+
         if [[ ${FIRST_HOST_ALL} == 'true' ]]; then
-            myscp "${FIRST_FILE}" "${configItemList[0]}" "${SECOND_FILE}" "${SECOND_HOST}"
+            myscp "${FIRST_FILE}" ${hostName} "${SECOND_FILE}" "${SECOND_HOST}"
         else
-            myscp "${FIRST_FILE}" "${FIRST_HOST}" "${SECOND_FILE}" "${configItemList[0]}"
+            myscp "${FIRST_FILE}" "${FIRST_HOST}" "${SECOND_FILE}" "${hostName}"
         fi
+
+        # increment before getting the next one
+        i=$((i+1))
     done
 }
 
@@ -129,6 +153,7 @@ myscp()
     local FIRST_HOST=$2
     local SECOND_FILE=$3
     local SECOND_HOST=$4
+
     if [[ -z ${FIRST_HOST} ]]; then
         if [[ ${DO_NOT_RUN} == 'true' ]]; then
             echo "scp -F ${TMP_CONFIG} ${FIRST_FILE} ${SECOND_HOST}:${SECOND_FILE}"
@@ -161,15 +186,19 @@ getKeyDir()
         # the Google Drive.  Since it could be named something else or just because it has a space in
         # the name, we need to expand it once so that we can use it below when finding the key.
         # dcCOMMON_SHARED_DIR is set when dcUtils is installed and put into the environmnet.
-        aKeyValue=$(grep dcCOMMON_SHARED_DIR ~/.dcConfig/settings)
-        var1=${aKeyValue#*\"}
-        dcCOMMON_SHARED_DIR=${var1%\"}
+        dcCOMMON_SHARED_DIR=$(getValueFromSettings "dcCOMMON_SHARED_DIR")
 
         if [[ -z ${dcCOMMON_SHARED_DIR} ]]; then
             COMMON_KEY_DIR=$(cd $HOME/Googl*;pwd)
         else
-            # now strip out the key and '=' to get to the path
-            COMMON_KEY_DIR=${dcCOMMON_SHARED_DIR#*=}
+            # now we need to check if this is internal or a customer
+            dcInternal=$(getValueFromSettings "dcInternal")
+            if [[ -z ${dcInternal} ]]; then
+                COMMON_KEY_DIR=${dcCOMMON_SHARED_DIR}
+            else
+                # its internal so adjust the path
+                COMMON_KEY_DIR=${dcCOMMON_SHARED_DIR%/*}
+            fi
         fi
     fi
 }
@@ -233,19 +262,88 @@ getPathToKey()
             eval "$pathToKey=\"${RETVAL}\""
         fi
     else
-        DC_COMMON_KEY_DIR=${COMMON_KEY_DIR%/*}
         if [[ -f "${COMMON_KEY_DIR}/devops.center/keys/${keyName}.pem" ]]; then
             RETVAL="${COMMON_KEY_DIR}/devops.center/keys/${keyName}.pem"
         elif [[ -f "${COMMON_KEY_DIR}/${PROFILE}/devops.center/keys/${keyName}.pem" ]]; then
             RETVAL="${COMMON_KEY_DIR}/${PROFILE}/devops.center/keys/${keyName}.pem"
-        elif [[ -f "${DC_COMMON_KEY_DIR}/${PROFILE}/devops.center/keys/${keyName}.pem" ]]; then
-            RETVAL="${DC_COMMON_KEY_DIR}/${PROFILE}/devops.center/keys/${keyName}.pem"
+        elif [[ -f ${HOME}/.ssh/devops.center/${keyName}.pem ]]; then
+            RETVAL="${HOME}/.ssh/devops.center/${keyName}.pem"
         else
             RETVAL="${COMMON_KEY_DIR}/${PROFILE}/keys/${keyName}.pem"
         fi
         eval "$pathToKey=\"${RETVAL}\""
     fi
 }
+
+
+#---  FUNCTION  ----------------------------------------------------------------
+#          NAME:  callInstanceInfo
+#   DESCRIPTION:  This function will call the instanceinfo.py script and give it
+#                 the appropriate arguments.  It will take as one argument the
+#                 string that names the shellCommand instanceinfo.py needs to run with
+#                 A second argument is the set of tags (as one string) to use
+#                 This second argument is optional
+#    PARAMETERS:
+#       RETURNS:
+#-------------------------------------------------------------------------------
+callInstanceInfo ()
+{
+    local shellCommand=$1
+    local tagToUse="$2"
+    local sortKey=$3
+
+    # we need to build up the command to run with the provided arguments
+    CMD_TO_RUN="${dcUTILS}/scripts/instanceinfo.py -sc ${shellCommand} -c ${PROFILE}"
+
+    if [[ -n ${REGION} ]]; then
+        CMD_TO_RUN+=" -r ${REGION} "
+    fi
+
+    if [[ -n $tagToUse ]]; then
+        #-------------------------------------------------------------------------------
+        # ensure there isn't a comma after each key=value pair
+        #-------------------------------------------------------------------------------
+        tagsNoComma=${tagToUse//,/}
+        CMD_TO_RUN+=" -t "
+        CMD_TO_RUN+="${tagsNoComma}"
+        CMD_TO_RUN+=" "
+        if [[ -n ${sortKey} ]]; then
+            CMD_OUTPUT=$(${CMD_TO_RUN} -t "${tagsNoComma}")
+            if [[ $? -eq 0 ]]; then
+                INST_INFO_OUTPUT=$(echo ${CMD_OUTPUT} | jq -c "sort_by(.${sortKey})" )
+            else
+                echo ${CMD_OUTPUT}
+                exit 1
+            fi
+        else
+            CMD_OUTPUT=$(${CMD_TO_RUN} -t "${tagsNoComma}")
+            if [[ $? -eq 0 ]]; then
+                INST_INFO_OUTPUT=${CMD_OUTPUT}
+            else
+                echo ${CMD_OUTPUT}
+                exit 1
+            fi
+        fi
+    else
+        if [[ -n ${sortKey} ]]; then
+            CMD_OUTPUT=$(${CMD_TO_RUN})
+            if [[ $? -eq 0 ]]; then
+                INST_INFO_OUTPUT=$(echo ${CMD_OUTPUT} | jq -c "sort_by(.${sortKey})" )
+            else
+                echo ${CMD_OUTPUT}
+                exit 1
+            fi
+        else
+            CMD_OUTPUT=$(${CMD_TO_RUN})
+            if [[ $? -eq 0 ]]; then
+                INST_INFO_OUTPUT=${CMD_OUTPUT}
+            else
+                echo ${CMD_OUTPUT}
+                exit 1
+            fi
+        fi
+    fi
+}  # -------- end function callInstanceInfo
 
 
 #---  FUNCTION  ----------------------------------------------------------------
@@ -293,71 +391,24 @@ determineHosts()
 
     if [[ -z ${FIRST_HOST} ]] && [[ -z ${SECOND_HOST} ]]; then
         #echo "you want to copy to one or many instances"
+        callInstanceInfo "listOfIPAddresses" "${TAG}" "InstanceName"
+        DESCRIBE_ALL=${INST_INFO_OUTPUT}
 
-        #-------------------------------------------------------------------------------
-        # if no -t option
-        #-------------------------------------------------------------------------------
-        if [[ -z "$TAG" ]]; then
-            #-------------------------------------------------------------------------------
-            # if no -t, create ssh config for all instances
-            #-------------------------------------------------------------------------------
-
-            if [[ ${REGION} ]]; then
-                SSH_CONFIG_VARS=($(aws --profile "$PROFILE" --region "$REGION" ec2 describe-instances --filters Name=instance-state-name,Values=running | jq -c '.Reservations[]|.Instances[]|[[.Tags[]|select(.Key | contains("Name"))|.Value],.PublicIpAddress,.KeyName]'))
-            else
-                SSH_CONFIG_VARS=($(aws --profile "$PROFILE"  ec2 describe-instances --filters Name=instance-state-name,Values=running | jq -c '.Reservations[]|.Instances[]|[[.Tags[]|select(.Key | contains("Name"))|.Value],.PublicIpAddress,.KeyName]'))
-            fi
-
-        #-------------------------------------------------------------------------------
-        # if -t option specified, create ssh config only for tagged instances
-        #-------------------------------------------------------------------------------
-        else
-            # remove any spaces between tags if there are any
-            tagsNoSpaces=${TAG//[[:blank:]]/}
-            # split on the , and create an array of tags:w
-            TAGS=(${tagsNoSpaces//,/ })
-
-            #-------------------------------------------------------------------------------
-            # create ssh config for tagged instances
-            #-------------------------------------------------------------------------------
-            if [[ ${REGION} ]]; then
-                CMD_TO_RUN="aws --profile "$PROFILE" --region "$REGION" ec2 describe-instances --filters Name=instance-state-name,Values=running "
-            else
-                CMD_TO_RUN="aws --profile "$PROFILE" ec2 describe-instances --filters Name=instance-state-name,Values=running "
-            fi
-            for tagLine in ${TAGS[@]}
-            do
-                KV=(${tagLine//=/ })
-                CMD_TO_RUN+="\"Name=tag-value,Values=${KV[1]}\" "
-            done
-            CMD_TO_RUN+="| jq -c '.Reservations[]|.Instances[]|[[.Tags[]|select(.Key | contains(\"Name\"))|.Value],.PublicIpAddress,.KeyName]'"
-
-            SSH_CONFIG_VARS=($(eval ${CMD_TO_RUN}))
-        fi
     else
-        # you have a single host to copy to so get the SSH_CONFIG_VARS for this host
+        # you have a single host to copy to so get the InstanceInfo for this host
         if [[ ${FIRST_HOST} ]]; then
             HOST_TO_USE=${FIRST_HOST}
         else
             HOST_TO_USE=${SECOND_HOST}
         fi
 
-        if [[ ${REGION} ]]; then
-            CMD_TO_RUN="aws --profile "$PROFILE" --region "$REGION" ec2 describe-instances --filters Name=instance-state-name,Values=running "
-        else
-            CMD_TO_RUN="aws --profile "$PROFILE" ec2 describe-instances --filters Name=instance-state-name,Values=running "
-        fi
-        CMD_TO_RUN+="\"Name=tag-value,Values=${HOST_TO_USE}\" "
-        CMD_TO_RUN+="| jq -c '.Reservations[]|.Instances[]|[[.Tags[]|select(.Key | contains(\"Name\"))|.Value],.PublicIpAddress,.KeyName]'"
+        # need to add the name
+        # TODO test this to see if we want to add to the tag or replace it
+        TAG+="Name=${HOST_TO_USE}"
+        callInstanceInfo "listOfIPAddresses" "${TAG}" "InstanceName"
+        DESCRIBE_ALL=${INST_INFO_OUTPUT}
 
-        SSH_CONFIG_VARS=($(eval ${CMD_TO_RUN}))
     fi
-
-# list out the destintaions
-#    for item in ${SSH_CONFIG_VARS[@]}
-#    do
-#        echo ${item}
-#    done
 }
 
 
@@ -377,38 +428,75 @@ createSSHConfigFile()
     fi
 
     #-------------------------------------------------------------------------------
-    # create and populate temporary .ssh/config file
+    # go through the instances returned and create a temporary .ssh/config.XXXXX
+    # file to use to access the hosts
     #-------------------------------------------------------------------------------
     TMP_CONFIG=$(mktemp "${HOME}"/.ssh/.config.XXXXX)
-    numSSH_CONFIG="${#SSH_CONFIG_VARS[@]}"
-    q=0
-    while [[ $q -lt ${numSSH_CONFIG} ]]; do
-        ITEMLIST=()
-        ITEMSTRING=''
-        ITEMSTRING=$(echo "${SSH_CONFIG_VARS[${q}]}"|tr -d ']["')
-        IFS=$','; ITEMLIST=($ITEMSTRING); unset IFS;
-        numItems=${#ITEMLIST[@]}
-        if [[ $numItems -gt 2 ]]; then
-            if [[ ${ITEMLIST[2]} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]];then
-                q=$(($q+1))
-                continue
-            fi
-            pathToKey=''
-            getPathToKey ${ITEMLIST[2]} pathToKey
-            NEW_SSH_CONFIG_VARS+=("${ITEMLIST[0]},${ITEMLIST[1]},${pathToKey}")
+    i=0
+    numItems=$(echo ${DESCRIBE_ALL} | jq -c 'length')
+    while [[ ${i} -lt ${numItems} ]]; do
+        hostName=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].InstanceName")
+        instancePublicIP=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].PublicIpAddress")
+        instancePrivateIP=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].PrivateIpAddress")
+        instancePublicPort=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].PublicPort")
+        instancePrivatePort=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].PrivatePort")
+        keyName=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].DestKey")
+        gateway=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].Gateway")
+
+        # now get the path to the key
+        pathToKey=''
+        getPathToKey ${keyName} pathToKey
+
+        # get the login if there is one
+        destLogin=$(echo ${DESCRIBE_ALL} | jq -r ".[${i}].DestLogin")
+        if [[ -z ${destLogin} ]]; then
+            destLogin="ubuntu"
         fi
-        q=$(($q+1))
+
+        # ok now we need to add the item to the temporary ssh config file
+        echo "Host ${hostName}" >> ${TMP_CONFIG}
+        if [[ -z ${instancePublicIP} ]]; then
+            # the private information goes here
+            echo " hostname ${instancePrivateIP}" >> ${TMP_CONFIG}
+            # and put the port
+            if [[ -z ${instancePrivatePort} ]]; then
+                echo " port 22" >> ${TMP_CONFIG}
+            else
+                echo " port ${instancePrivatePort}" >> ${TMP_CONFIG}
+            fi
+        else
+            # put the public information
+            echo " hostname ${instancePublicIP}" >> ${TMP_CONFIG}
+            # and put the port
+            if [[ -z ${instancePublicPort} ]]; then
+                echo " port 22" >> ${TMP_CONFIG}
+            else
+                echo " port ${instancePublicPort}" >> ${TMP_CONFIG}
+            fi
+        fi
+        echo " identityfile \"${pathToKey}\"" >> ${TMP_CONFIG}
+        echo " user ${destLogin}" >> ${TMP_CONFIG}
+        if [[ ! -z ${gateway} ]]; then
+            # there is a gateway entry so we need to get the connect parts for this instance
+            callInstanceInfo "connectParts" "Name=${hostName}"
+            gatewayInfo=${INST_INFO_OUTPUT}
+
+            jumpServerHost=$(echo ${gatewayInfo} | jq -r ".[].JumpServerHost")
+            jumpServerPort=$(echo ${gatewayInfo} | jq -r ".[].JumpServerPort")
+            jumpServerLogin=$(echo ${gatewayInfo} | jq -r ".[].JumpServerLogin")
+            jumpServerKey=$(echo ${gatewayInfo} | jq -r ".[].JumpServerKey")
+
+            jumpServerPathToKey=''
+            getPathToKey ${jumpServerKey} jumpServerPathToKey
+            jumpServerCommand="ProxyCommand "ssh -i ${jumpServerPathToKey} -W %h:%p -p ${jumpServerPort} ${jumpServerLogin}@${jumpServerHost}"
+            echo " ${jumpServerCommand}" >> ${TMP_CONFIG}
+        fi
+        echo >> ${TMP_CONFIG}
+
+        # increment before getting the next one
+        i=$((i+1))
     done
 
-    for theItem in "${NEW_SSH_CONFIG_VARS[@]}"
-    do
-        IFS=$','; configItemList=($theItem); unset IFS;
-        echo "Host ${configItemList[0]}" >> $TMP_CONFIG
-        echo " hostname ${configItemList[1]}" >> $TMP_CONFIG
-        echo " identityfile \"${configItemList[2]}\"" >> $TMP_CONFIG
-        echo " user ubuntu" >> $TMP_CONFIG
-        echo >> $TMP_CONFIG
-    done
 }
 
 

--- a/pawscp
+++ b/pawscp
@@ -34,8 +34,8 @@ function usage
     echo -e "    pawscp is a tool that makes it easier to transfer files to and from and AWS EC2 instances.   \n"
     echo -e "Usage:"
     echo -e "    Optional arguments that can be used with any other combination of arguments:"
-    echo -e "    [-p PROFILE] [-r REGION] [-t \"TAG=VALUE\"\n"
-    echo -e "    [host/all:]file1 [host/all:]file2" 
+    echo -e "    [-p PROFILE] [-r REGION] [--quiet] [-t \"TAG=VALUE OTHERTAG=OTHERVALUE\"]\n"
+    echo -e "    [host/all]:file1 [host/all]:file2"
     echo 
     echo -e "  NOTE: the file1 and file2 arguments need to be the last two arguments"
     echo 
@@ -47,6 +47,9 @@ function usage
    # echo -e "    If there is no 'host:' or 'all:' -  it will take file1 and transfer it to all hosts found for PROFILE and REGION"
    # echo -e "        at the file2 location"
     echo -e "    If host is missing from either and each has a colon: that's an error since it doesn't know where to put it"
+    echo -e "    By default it will express what is being transferred to where, good from the command line to see what"
+    echo -e "       is happening.  However, if run from scripts a lot of times you don't want that output, so there is"
+    echo -e "       an option -q|--quiet to suppress that output."
     echo -e "Examples:"
     echo -e "    copy a file from the local machine to a specific destination host and put the file in the home directory."
     echo -e "    pawscp -p devops.center ~/filetotransfer destHost:~"


### PR DESCRIPTION
Made the changes to pawscp to utilize instanceinfo.py.
Also, made the change to allow wildcards to be used in the file names to be transferred, with the caveat that they would have to be quoted on the command line.  The downside of this, the file(s) being transferred can not have a space in the file name.