### PR TITLE
Access shared settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,33 +431,34 @@ delete or change it.
 
 ### Multiple base directories - Work Spaces
 By default the idea of working with the devops.center environment is that there is
-one default workspace named: default.  This default workspace has a directory
+one workspace that has the name of the customer.  This workspace has a directory
 associated with it, and one or more applications would reside side by side in this
 directory.  By doing this, it is easier to automate setting up environment variables
 specific to an application.  The framework knows this because the information is
 written in: $HOME/.dcConfig/baseDirectory.  When you create your first application
 this file will be constructed and the directory will placed into the file with the
-workspace name set to 'default'.  
+workspace name set to name of the customer (lowercase and no spaces in the name).  
 
 If you have the need or desire to support multiple workspaces (say you have two
-customers or you just want to keep two or more applications separate), you can use
-the --workspaceName (-w) option on any of the scripts and specify the workspace you
-want to reference.  The script will read the $HOME/.dcConfig/baseDirectory file and
-determine the base path for that name and use it appropriately.  You will need to
-use the --baseDirectory (-d) option when building a new application with manageApp.py
-and will also need the --workspaceName option.  This should be the only time you
-would need to add the --baseDirectory option with manageApp.py
+customers or you just want to keep two or more applications separate), you would
+use the addWorkspace.sh script to create a new workspace.  This script will set up
+a new directory using the directory defined by the DEV_BASE_DIR key in 
+$HOME/.dcConfig/settings.  If you want it in a different base directory provide
+the -d option.  
+You will need to use the --workspaceName (-w) option when building or joining 
+a new application with manageApp.py in order to specify where you want to place
+the applicaiton.  You can use the workspace option with other scripts to direct
+the focus of the script you are running on that workspace.
 
-Also, if you are going to be doing a lot of work in this workspace you can use the
-switchWorkspace.sh script to change the default workspace to this name.  Then you
-would not have to give the --workspaceName option each time you execute a script.
-To set the default to the new workspaceName execute:
+Also, if you have more then one workspace you can switch between them using the
+switchWorkspace.sh script.  Then you would not have to give the --workspaceName
+ption each time you execute a script. To switch the workspace to a new workspaceName
+ execute:
 
     switchWorkspace.sh -n new-name
 
 If you don't provide an option it will give you a help message and show you what the
 current default workspace name is along with any other workspaces you have defined.
-If you want to go back to the default unnamed workspace, enter the word "default" as the new name.
 
 
 ## Contributing

--- a/addWorkspace.sh
+++ b/addWorkspace.sh
@@ -163,7 +163,7 @@ else
             echo "CURRENT_WORKSPACE=${WORKSPACE_NAME_UPPERCASE}" > "${theFile}.NEW"
             continue
         fi
-        if [[ ${aLine} == "##### WORKSPACES ######"* ]]; then
+        if [[ ${aLine} == "##### WORKSPACES ####"* ]]; then
             writeNewEntry="true"
         fi 
         echo "${aLine}" >> $HOME/.dcConfig/baseDirectory.NEW

--- a/addWorkspace.sh
+++ b/addWorkspace.sh
@@ -51,7 +51,7 @@
 #-------------------------------------------------------------------------------
 usage ()
 {
-    echo -e "Usage: addWorkspace.sh -n newWorkspaceName -d destinationDirectory"
+    echo -e "Usage: addWorkspace.sh -n newWorkspaceName -d baseDirectory"
     echo
     echo -e "This script will add a workspace that you can use to separate an"
     echo -e "application from other applications.  This will create a parent"

--- a/addWorkspace.sh
+++ b/addWorkspace.sh
@@ -177,7 +177,10 @@ else
     rm "${theFile}.ORIG"
 fi
 
-# and finally make the new directory in the location specified
+# and now make the new directory in the location specified
 if [[ ! -d "${dirToAdd}" ]]; then
     mkdir -p "${dirToAdd}"
 fi 
+
+# and finally we need to switch workspaces over to this new one
+switchWorkspace.sh -n ${A_WORKSPACE_NAME}

--- a/addWorkspace.sh
+++ b/addWorkspace.sh
@@ -62,15 +62,35 @@ usage ()
     echo -e "Required arguments:"
     echo -e "-n  This is the name of the new workspace that you want to add"
     echo -e "    NOTE: do not put spaces in the name."
-    echo -e "-d  This is the base directory where the parent directory with "
+    echo -e "-d  [OPTIONAL] This is the base directory where the parent directory with "
     echo -e "    the name of the workspace will be created."
+    echo -e "    If not given it will take the value of DEV_BASE_DIR from ~/.dcConfig/settings"
+
     echo
 }
+
+
+#---  FUNCTION  ----------------------------------------------------------------
+#          NAME:  getValueFromSettings
+#   DESCRIPTION:  will get the value of the key passed in from ~/.dcConfig/settings
+#    PARAMETERS:  the key to look for
+#       RETURNS:  the value of the key once it's found
+#-------------------------------------------------------------------------------
+getValueFromSettings()
+{
+    keyToFind=$1
+    aKeyValue=$(grep "^${keyToFind}" ~/.dcConfig/settings)
+    justTheValue=${aKeyValue#*=}
+    # remove any double quotes around the value
+    var1=${justTheValue#*\"}
+    unquotedVar=${var1%\"}
+    echo "${unquotedVar#*=}"
+}       # ----------  end of function getValueFromSettings  ----------
 
 #-------------------------------------------------------------------------------
 # Make sure there are the exact number of arguments
 #-------------------------------------------------------------------------------
-if [[ $# -ne 4 ]]; then
+if [[ $# -lt 2 ]]; then
     usage
     exit 1
 fi
@@ -80,6 +100,7 @@ fi
 #-------------------------------------------------------------------------------
 NEW_WORKSPACE_NAME=""
 
+DEST_DIR=''
 while [[ $# -gt 0 ]]; do
     case ${1} in
       "-n" )   shift
@@ -98,6 +119,12 @@ if [[ "${A_WORKSPACE_NAME}" == *[[:space:]]* ]]; then
     echo "Error: The workspace name can not contains spaces: ${A_WORKSPACE_NAME}"
     exit 1
 fi
+
+if [[ ! ${DEST_DIR} ]]; then
+    DEST_DIR=$(getValueFromSettings "DEV_BASE_DIR")
+fi
+
+echo "NOTE: adding workspace ${A_WORKSPACE_NAME} to ${DEST_DIR}"
 
 # make sure the workspace nane is uppercase
 WORKSPACE_NAME_UPPERCASE=${A_WORKSPACE_NAME^^}

--- a/addWorkspace.sh
+++ b/addWorkspace.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#===============================================================================
+#
+#          FILE: addWorkspace.sh
+#
+#         USAGE: ./addWorkspace.sh
+#
+#   DESCRIPTION: This script will add a new separation between applications by
+#                adding a new workspace.  This way additional applicaiotns can
+#                be associated with this workspace and they are separate from
+#                other applications in other workspaces.
+#
+#       OPTIONS: ---
+#  REQUIREMENTS: ---
+#          BUGS: ---
+#         NOTES: ---
+#        AUTHOR: Bob Lozano - bob@devops.center
+#                Gregg Jensen - gjensen@devops.center
+#  ORGANIZATION: devops.center
+#       CREATED: 08/23/2018 10:50:48
+#      REVISION:  ---
+#
+# Copyright 2014-2018 devops.center llc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#===============================================================================
+
+#set -o nounset     # Treat unset variables as an error
+#set -o errexit     # exit immediately if command exits with a non-zero status
+#set -o verbose     # print the shell lines as they are executed
+#set -x             # essentially debug mode
+
+
+#---  FUNCTION  ----------------------------------------------------------------
+#          NAME:  usage
+#   DESCRIPTION:  function that gets called to show the user how this script should
+#                 be called and what the arguments mean
+#    PARAMETERS:
+#       RETURNS:
+#-------------------------------------------------------------------------------
+usage ()
+{
+    echo -e "Usage: addWorkspace.sh -n newWorkspaceName -d destinationDirectory"
+    echo
+    echo -e "This script will add a workspace that you can use to separate an"
+    echo -e "application from other applications.  This will create a parent"
+    echo -e "directory that applications that will be associated with this workspace"
+    echo -e "will be placed."
+    echo -e "Note: this creates/adds to the baseDirectory file located in ~/.dcConfig"
+    echo
+    echo -e "Required arguments:"
+    echo -e "-n  This is the name of the new workspace that you want to add"
+    echo -e "    NOTE: do not put spaces in the name."
+    echo -e "-d  This is the base directory where the parent directory with "
+    echo -e "    the name of the workspace will be created."
+    echo
+}
+
+#-------------------------------------------------------------------------------
+# Make sure there are the exact number of arguments
+#-------------------------------------------------------------------------------
+if [[ $# -ne 4 ]]; then
+    usage
+    exit 1
+fi
+
+#-------------------------------------------------------------------------------
+# Loop through the arguments and assign input args with the appropriate variables
+#-------------------------------------------------------------------------------
+NEW_WORKSPACE_NAME=""
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+      "-n" )   shift
+             A_WORKSPACE_NAME="${1}"
+             ;;
+      "-d" )   shift
+             DEST_DIR="${1}"
+             ;;
+      * )    usage
+             exit 1
+    esac
+    shift
+done
+
+if [[ "${A_WORKSPACE_NAME}" == *[[:space:]]* ]]; then
+    echo "Error: The workspace name can not contains spaces: ${A_WORKSPACE_NAME}"
+    exit 1
+fi
+
+# make sure the workspace nane is uppercase
+WORKSPACE_NAME_UPPERCASE=${A_WORKSPACE_NAME^^}
+#echo ${WORKSPACE_NAME_UPPERCASE}
+#echo "${DEST_DIR}"
+
+varToAdd="_${WORKSPACE_NAME_UPPERCASE}_BASE_CUSTOMER_DIR="
+dirToAdd="${DEST_DIR}/${A_WORKSPACE_NAME}"
+lineToAdd="${varToAdd}${dirToAdd}"
+theFile=$HOME/.dcConfig/baseDirectory
+
+# see if it exists maybe this is the first time 
+if [[ ! -f "${theFile}" ]]; then
+    # create it and make sure that this workspace is the current workspace
+    echo "CURRENT_WORKSPACE=${WORKSPACE_NAME_UPPERCASE}" > "${theFile}"
+    echo "##### WORKSPACES ######" >> "${theFile}"
+    echo ${lineToAdd} >> "${theFile}"
+    echo "##### BASE DIR CONSTRUCTION NO TOUCH ######" >> "${theFile}"
+    echo 'CONSTRUCTED_BASE_DIR=_${CURRENT_WORKSPACE}_BASE_CUSTOMER_DIR' >> "${theFile}"
+    echo 'BASE_CUSTOMER_DIR=${!CONSTRUCTED_BASE_DIR}' >> "${theFile}"
+else
+    # check to see if there is a value by that name already in the file
+    if [[ ! $(grep -c ${varToAdd} ${theFile}) ]];then
+        echo "A workspace with the same name exists: ${A_WORKSPACE_NAME}"
+        exit 1
+    fi
+    
+    # need to add a line into that file and we need to do it in a way that will
+    # work for both linux and osx, since we can rely on the verion of sed they have
+    cp "${theFile}" "${theFile}.ORIG"
+    writeNewEntry="false"
+    # we'll put all the new lines into a new file so we don't screw up the file 
+    # we are reading
+    while read aLine; do
+        if [[ $aLine == "CURRENT_WORKSPACE"* ]]; then
+            echo "CURRENT_WORKSPACE=${WORKSPACE_NAME_UPPERCASE}" > "${theFile}.NEW"
+            continue
+        fi
+        if [[ ${aLine} == "##### WORKSPACES ######"* ]]; then
+            writeNewEntry="true"
+        fi 
+        echo "${aLine}" >> $HOME/.dcConfig/baseDirectory.NEW
+        if [[ ${writeNewEntry} == "true" ]]; then
+            echo ${lineToAdd} >> "${theFile}.NEW"
+            writeNewEntry="false"
+        fi
+    done < "${theFile}"
+    # and now do some house cleaning
+    mv "${theFile}.NEW" "${theFile}"
+    rm "${theFile}.ORIG"
+fi
+

--- a/addWorkspace.sh
+++ b/addWorkspace.sh
@@ -177,3 +177,7 @@ else
     rm "${theFile}.ORIG"
 fi
 
+# and finally make the new directory in the location specified
+if [[ ! -d "${dirToAdd}" ]]; then
+    mkdir -p "${dirToAdd}"
+fi 

--- a/addWorkspace.sh
+++ b/addWorkspace.sh
@@ -61,7 +61,7 @@ usage ()
     echo
     echo -e "Required arguments:"
     echo -e "-n  This is the name of the new workspace that you want to add"
-    echo -e "    NOTE: do not put spaces in the name."
+    echo -e "    NOTE: do not put spaces in the name and all letters should be lowercase."
     echo -e "-d  [OPTIONAL] This is the base directory where the parent directory with "
     echo -e "    the name of the workspace will be created."
     echo -e "    If not given it will take the value of DEV_BASE_DIR from ~/.dcConfig/settings"
@@ -134,7 +134,7 @@ WORKSPACE_NAME_UPPERCASE=${A_WORKSPACE_NAME^^}
 #echo "${DEST_DIR}"
 
 varToAdd="_${WORKSPACE_NAME_UPPERCASE}_BASE_CUSTOMER_DIR="
-dirToAdd="${DEST_DIR}/${A_WORKSPACE_NAME}"
+dirToAdd="${DEST_DIR}/${A_WORKSPACE_NAME,,}"
 lineToAdd="${varToAdd}${dirToAdd}"
 theFile=$HOME/.dcConfig/baseDirectory
 
@@ -194,6 +194,8 @@ fi
 #-------------------------------------------------------------------------------
 settingsFile=~/.dcConfig/settings
 if [[ ! $(grep -c CURRENT_WORKSPACE "${settingsFile}") ]]; then
+    sed -i -e "s/CURRENT_WORKSPACE=.*/CURRENT_WORKSPACE=${A_WORKSPACE_NAME,,}/" "${settingsFile}"
+else
     cp "${settingsFile}" "${settingsFile}.ORIG"
     writeNewEntry="false"
     # we'll put all the new lines into a new file so we don't screw up the file 

--- a/manageApp.py
+++ b/manageApp.py
@@ -46,6 +46,7 @@ from time import time
 import fileinput
 import re
 from scripts.process_dc_env import pythonGetEnv
+from scripts.sharedsettings import SharedSettings
 # ==============================================================================
 """
 This script provides an administrative interface to a customers application set
@@ -95,56 +96,59 @@ def getCommonSharedDir():
 
 class ManageAppName:
 
-    def __init__(self, theAppName, baseDirectory, altName, appPath,
-                 sharedUtilsFlag, utilsPath, envList):
+    def __init__(self, theAppName, baseDirectory, altName, envList, appPath=None):
         """ManageAppName constructor"""
         self.organization = None
         self.appName = theAppName
         self.dcAppName = ''
         self.appPath = appPath
-        self.utilsPath = utilsPath
         self.baseDir = baseDirectory
         self.altName = altName.upper()
         self.dcUtils = os.environ["dcUTILS"]
         self.envList = envList
-        self.sharedUtilsFlag = sharedUtilsFlag
+
 
         self.organization = self.envList["CUSTOMER_NAME"]
         if "WORKSPACE_NAME_ORIGINAL" in self.envList:
             self.organization = self.envList["WORKSPACE_NAME_ORIGINAL"]
 
-        if self.sharedUtilsFlag:
-            # set up the defaults for the shared info and check to see if
-            # we are using a shared environment for this app
-            self.sharedUtilsName = "dcShared-utils"
+        # set up the defaults for the shared info and check to see if
+        # we are using a shared environment for this app
+        self.sharedUtilsName = "dcShared-utils"
 
-            # check to see if the shared config directory exists
-            commonSharedDir = getCommonSharedDir()
-            internalCheck = getSettingsValue("dcInternal")
+        # check to see if the shared config directory exists
+        commonSharedDir = getCommonSharedDir()
+        internalCheck = getSettingsValue("dcInternal")
 
-            if internalCheck:
-                sharedSettingsDir = commonSharedDir + "/" + self.organization + "/devops.center/dcConfig"
-            else:
-                sharedSettingsDir = commonSharedDir + "/devops.center/dcConfig"
+        if internalCheck:
+            sharedSettingsDir = commonSharedDir + "/" + self.organization + "/devops.center/dcConfig"
+        else:
+            sharedSettingsDir = commonSharedDir + "/devops.center/dcConfig"
 
-            if not os.path.exists(sharedSettingsDir):
-                print("ERROR: the directory for the shared settings file was not found:\n"
-                      + sharedSettingsDir +
-                      "Please let the devops.center engineers know and they"
-                      " will assist with correcting this.")
-                sys.exit(1)
-            else:
-                self.sharedSettingsPath = sharedSettingsDir
+        if not os.path.exists(sharedSettingsDir):
+            print("ERROR: the directory for the shared settings file was not found:\n"
+                    + sharedSettingsDir +
+                    "Please let the devops.center engineers know and they"
+                    " will assist with correcting this.")
+            sys.exit(1)
+        else:
+            self.sharedSettingsPath = sharedSettingsDir
 
-            self.sharedSettingsFile = self.sharedSettingsPath + "/settings"
-            if not os.path.isfile(self.sharedSettingsFile):
-                print("ERROR: the shared settings file was not found:\n"
-                      + self.sharedSettingsFile +
-                      "\nEither you do not have the shared directory "
-                      "or the settings file has not been created.\n"
-                      "Please let the devops.center engineers know and they"
-                      " will assist with correcting this.")
-                sys.exit(1)
+        self.sharedSettingsFile = self.sharedSettingsPath + "/settings.json"
+        if not os.path.isfile(self.sharedSettingsFile):
+            print("ERROR: the shared settings file was not found:\n"
+                    + self.sharedSettingsFile +
+                    "\nEither you do not have the shared directory "
+                    "or the settings file has not been created.\n"
+                    "Please let the devops.center engineers know and they"
+                    " will assist with correcting this.")
+            sys.exit(1)
+
+        # need to get the information from the shared settings about the 
+        # application VCS (git) URL(s) and the utilities URL.  This was
+        # created when the application was created
+        self.theSharedSettings = SharedSettings(self.sharedSettingsFile)
+        self.sharedUtilsFlag = self.theSharedSettings.isShared(self.appName)
 
         # put the baseDirectory path in the users $HOME/.dcConfig/baseDirectory
         # file so that subsequent scripts can use it as a base to work
@@ -302,11 +306,6 @@ class ManageAppName:
         NOTE: the pound noqa after the method name will turn off the warning
         that the method is to complex."""
 
-        if (not self.appPath):
-            print("ERROR: you must provide at the minimum the option --appPath"
-                  " to join and existing application.")
-            sys.exit(1)
-
         # create the dataload directory...this is a placeholder and can
         # be a link to somewhere else with more diskspace.  But that is
         # currently up to the user.
@@ -318,73 +317,17 @@ class ManageAppName:
         # change to the baseDirectory
         os.chdir(basePath)
 
-        if re.match("http", self.appPath) or re.search(".git$", self.appPath):
-            # they have entered a git repo for the existing front end directory
-            self.joinWithGit(basePath, "web", self.appPath)
-        else:
+        if self.appPath:
             # they have entered a path to an existing front end directory
             self.joinWithPath(basePath, "web", self.appPath)
-
-        if self.sharedUtilsFlag:
-            # lets check for the existance of this app in the dcShared-utils
-            # if it''s not there then there is no sense in continuing
-            strToSearch = self.appName + "-utils=shared"
-            if strToSearch not in open(self.sharedSettingsFile).read():
-                print('This app does not appear to have been created or shared '
-                      'as it is not in the\n' + self.sharedSettingsFile + '\n'
-                      'as a result it will not be in the dcShared-utils repo. '
-                      'Check to see if this app has been created and if it was '
-                      'supposed to be shared. Exiting ...')
-                sys.exit(1)
-
-        if self.sharedUtilsFlag:
-            gitUtilsPath = None
-            try:
-                with open(self.sharedSettingsFile) as fp:
-                    for aLine in fp:
-                        strippedLine = aLine.strip()
-                        if "SHARED_APP_REPO" in strippedLine:
-                            gitUtilsPath = strippedLine.split("=")[1]
-                            break
-                if gitUtilsPath:
-                    # since this is a shared repo for the app-utils it resides
-                    # in a different place (peer to the app directories in
-                    # the baseDir) hence we need to pass this path on to the
-                    # next methods and they will do the right thing in the
-                    # right place (ie they will clone if the directory
-                    # doesn't exist, otherwise it will do a pull)
-                    basePath = self.baseDir + self.sharedUtilsName
-                    if re.match("http", gitUtilsPath) or \
-                            re.search(".git$", gitUtilsPath):
-                            # they have entered a git repo for the existing
-                            # utilities directory
-                        self.joinWithGit(basePath, "utils", gitUtilsPath)
-                    else:
-                        # TODO need to remove the app-web that was pulled down
-                        # if we get to here.
-                        print('ERROR: the URL for the shared app-utils '
-                              'repository '
-                              ' is invalid or unsupported: ' + gitUtilsPath +
-                              '\n You will need retry this command after '
-                              'that is corrected.')
-            except IOError:
-                print('Error: trying to get the shared file that contains the '
-                      'respository that has this\napplications devops.center '
-                      'utilities could not be found. \nThis could either be '
-                      'because this application hasnt been created yet or '
-                      'you\ndont have acces to the share drive that contians '
-                      'the file.')
-                sys.exit(1)
         else:
-            if re.match("http", self.utilsPath) or \
-                    re.search(".git$", self.utilsPath):
-                # they have entered a git repo for the existing utilities
-                # directory
-                self.joinWithGit(basePath, "utils", self.utilsPath)
-            else:
-                # they have entered a path to an existing utilies directory
-                self.joinWithPath(basePath, "utils", self.utilsPath)
+            appSrcList = self.theSharedSettings.getApplicationRepoList(self.appName)
+            for aURL in appSrcList:
+                self.joinWithGit(basePath, "web", aURL)
 
+        # get the app-utils
+        self.joinWithGit(basePath, "utils", self.theSharedSettings.getUtilitiesRepo(self.appName))
+        
         # and the environments directory
         envDir = basePath + "/" + self.utilsDirName + "/environments"
         if not os.path.exists(envDir):
@@ -421,13 +364,6 @@ class ManageAppName:
         self.createDockerComposeFiles()
         print("\n\nDone")
         # self.createStackDirectory()
-        # self.createAWSProfile()
-
-        # TODO need to decide if there is a git init at the top level
-        # of do it in each of the sub directories (ie, appName-utils,
-        # appName-web, and uniqueID-stack).  I think it should be the separate
-        # ones. So the .gitignore may need to be down in the appropriate sub
-        # directory.
 
     def createBaseDirectories(self):
         basePath = self.baseDir + self.appName
@@ -658,7 +594,7 @@ class ManageAppName:
             fileHandle.close()
         except IOError:
             print("NOTE: There is a file that needs to be created: \n" +
-                  self.basedir + self.appName + "/.dcDirMap.cnf and "
+                  self.baseDir + self.appName + "/.dcDirMap.cnf and "
                   "could not be written. \n"
                   "Please report this issue to the devops.center admins.")
 
@@ -755,6 +691,9 @@ class ManageAppName:
                     name + "\n"
                     "APP_UTILS_KEYS=${dcHOME}/" + appUtilsDir + "/keys/" +
                     name + "\n"
+                    "#\n"
+                    "dcEnv=" + name + "\n"
+                    "#\n"
                     "#\n")
                 fileHandle.write(strToWrite)
             except IOError:
@@ -769,6 +708,7 @@ class ManageAppName:
             strToWrite = (
                 "# some app env vars specific to the environment\n"
                 "dcHOME=~/" + self.appName + "\n"
+                "dcTempDir=/media/data/tmp\n"                             
                 "\n#\n"
                 "# Papertrail settings\n"
                 "#\n"
@@ -795,6 +735,9 @@ class ManageAppName:
                 "# some app env vars specific to the environment\n"
                 "APP_UTILS_CONFIG=${dcHOME}/" + appUtilsDir + "config/local\n"
                 "APP_UTILS_KEYS=${dcHOME}/" + appUtilsDir + "keys\n"
+                "#\n"
+                "dcEnv=local\n"
+                "#\n"
                 "\n#\n"
                 "# Papertrail settings\n"
                 "#\n"
@@ -815,69 +758,6 @@ class ManageAppName:
 
         # and now for the personal.env file
         self.createPersonalEnv(envDir)
-
-    def createAWSProfile(self):
-        """This method will create the necessary skeleton in the .aws directory
-        for the new appName which will be used as the profile name"""
-
-        # TODO determine if this is a good thing to do...By doing this the
-        # .aws config and credentials could be set up and then the user would
-        # have to fill it in.  But the region wouldn't be known and the keys
-        # would not be known.  The reason for doing this is that if the user
-        # goes through the aws configure steps and doesn't do the profile or
-        # gives a different profile name than the appName then things wont
-        # work right.
-
-        # first check for the existance of the .aws directory
-        configFileWriteFlag = 'w'
-        credentialFileWriteFlag = 'w'
-        awsBaseDir = expanduser("~") + "/.aws"
-        if os.path.exists(awsBaseDir):
-            # and then check for the existance of the config and credentials
-            # files
-            if os.path.isfile(awsBaseDir + "/config"):
-                configFileWriteFlag = 'a'
-            if os.path.isfile(awsBaseDir + "/credentials"):
-                credentialFileWriteFlag = 'a'
-        else:
-            # create the directory
-            if not os.path.exists(awsBaseDir):
-                os.makedirs(awsBaseDir)
-
-        # now add the necessary entries in config
-        awsConfigFile = awsBaseDir + "/config"
-        try:
-            fileHandle = open(awsConfigFile, configFileWriteFlag)
-            strToWrite = ("[profile " + self.appName + "]\n"
-                          "output = json\n"
-                          "region = us-west-2\n")
-            fileHandle.write(strToWrite)
-            fileHandle.close()
-        except IOError:
-            print("NOTE: There is a file that needs to be created: \n"
-                  "$HOME/.aws/config and could not be written. \n"
-                  "Please report this issue to the devops.center admins.")
-
-        # now add the necessary entries in credentials
-        awsCredentialsFile = awsBaseDir + "/credentials"
-        try:
-            fileHandle = open(awsCredentialsFile, credentialFileWriteFlag)
-            strToWrite = "[" + self.appName + "]\n" + \
-                "aws_access_key_id = YOUR_ACCESS_KEY_ID_HERE\n" + \
-                "aws_secret_access_key = YOUR_SECRET_ACCESS_KEY_HERE\n"
-            fileHandle.write(strToWrite)
-            fileHandle.close()
-        except IOError:
-            print("NOTE: There is a file that needs to be created: \n"
-                  "$HOME/.aws/credentials and could not be written. \n"
-                  "Please report this issue to the devops.center admins.")
-
-        print("\nYou will need to add your AWS access and secret key to \n"
-              "the ~/.aws/credentials file and will need to check the \n"
-              "region in the ~/.aws/config file to ensure it is set to  \n"
-              "correct AWS region that your instances are created in.\n"
-              "Look for these entries under the profile name: \n" +
-              self.appName + "\n\n")
 
     def createDockerComposeFiles(self):
         """This method will create the Dockerfile(s) as necessary for this
@@ -1014,7 +894,7 @@ class ManageAppName:
                 fileHandle.close()
             except IOError:
                 print("NOTE: There is a file that needs to be "
-                      "created: \n" + self.basedir + self.appName +
+                      "created: \n" + self.baseDir + self.appName +
                       "/.dcDirMap.cnf and could not be written. \n"
                       "Please report this issue to the devops.center "
                       "admins.")
@@ -1075,7 +955,7 @@ class ManageAppName:
             fileHandle.close()
         except IOError:
             print("NOTE: There is a file that needs to be "
-                  "created: \n" + self.basedir + self.appName +
+                  "created: \n" + self.baseDir + self.appName +
                   "/.dcDirMap.cnf and could not be written. \n"
                   "Please report this issue to the devops.center "
                   "admins.")
@@ -1238,7 +1118,7 @@ class ManageAppName:
         # the git service name and the git account should be stored in
         # the shared settings file (created upon RUN-ME_FIRST.SH run by the
         # first person of a new customer.)
-        gitServiceName = "github"
+        gitServiceName = self.theSharedSettings.getVCSServiceName()
         gitAccountName = self.organization
 
         retRepoURL = None
@@ -1256,16 +1136,11 @@ class ManageAppName:
                 retRepoURL = "git@github.com:" + gitAccountName + \
                     '/dcShared-utils.git'
 
-            # TODO this repo name is probably not correct and needs to
-            # be updated
             elif gitServiceName == "assembla":
                 retRepoURL = "git@gassembla.com:" + gitAccountName + \
                     '/dcShared-utils.git'
-
-            # TODO this repo name is probably not correct and needs to
-            # be updated
             elif gitServiceName == "bitbucket":
-                retRepoURL = 'gituser@bitbucket.com:' + gitAccountName + \
+                retRepoURL = 'git@bitbucket.org:' + gitAccountName + \
                     '/dcShared-utils.git'
 
         else:
@@ -1428,8 +1303,7 @@ def checkArgs():
         'Example command line to join with an application:\n'
         './manageApp.py --appName YourApp\n'
         '            --command join\n'
-        '            --appPath git@git.assembla.com:website.git \n'
-        '            --utilsPath https://zsoqe@bitbucket.org/team/appUtils.git'
+        '\n ... or you can leave the command off as the default is to join.\n'
         '\n\n'
         'Example cmd line to update an application with a new environment:\n'
         './manageApp.py --appName YourApp\n'
@@ -1437,13 +1311,15 @@ def checkArgs():
         '            --option "newEnv=UAT"\n',
 
         formatter_class=RawDescriptionHelpFormatter)
-    parser.add_argument('-d', '--baseDirectory', help='The base directory '
+    parser.add_argument('-d', '--baseDirectory', help='[OPTIONAL] The base directory '
                         'to be used to access the appName. This needs to be '
                         'an absolute path unless the first part of the path '
-                        'is a tilde or $HOME.   This option is not required '
-                        'but is needed when using the workspaceName option.',
+                        'is a tilde or $HOME.   This option is '
+                        'needed when using the workspaceName option '
+                        'and reads from the personal settings in '
+                        '$HOME/.dcConfig/settings',
                         required=False)
-    parser.add_argument('-c', '--command', help='Command to execute' +
+    parser.add_argument('-c', '--command', help='[OPTIONAL] Command to execute' +
                         'on the appName. Default [join]',
                         choices=["join",
                                  "create",
@@ -1452,32 +1328,20 @@ def checkArgs():
                                  "getUniqueID"],
                         default='join',
                         required=False)
-    parser.add_argument('-p', '--appPath', help='The customer application '
-                        'repo URL or a path to an existing directory that '
-                        'houses the application front end. If you provide a '
-                        'path it should be an the full absolute path as it '
-                        'will be symobolically linked to the base directory '
-                        'given in this command. NOTE: tilde(~) or $HOME will '
-                        'be expanded appropriately',
-                        default='',
-                        required=False)
-    parser.add_argument('-u', '--utilsPath', help='The customer utils '
-                        'repo URL or a path to an existing directory that '
-                        'houses the application utilities. If you provide a '
-                        'path it should be an the full absolute path as it '
-                        'will be symobolically linked to the base directory '
-                        'given or into the app directory if the --sharedUtils'
-                        ' option is given. NOTE: tilde(~) or $HOME will '
-                        'be expanded appropriately',
+    parser.add_argument('-p', '--appPath', help='[OPTIONAL] This is the path to an existing '
+                        'application source code directory (rather then pulling it '
+                        'down from a VCS again, hence duplicating code) that '
+                        'houses the front end source code. The '
+                        'path it should be the full absolute path as it '
+                        'will be symobolically linked to the base directory. '
+                        'NOTE: tilde(~) or $HOME will be expanded appropriately',
                         default='',
                         required=False)
     parser.add_argument('-o', '--cmdOptions', help='Options for the '
-                        'command arg',
+                        'command arg.  Currently, this is used for creating a '
+                        'new environment othere then; dev, staging, local or prod.'
+                        'see the example above for the format.',
                         default='',
-                        required=False)
-    parser.add_argument('-s', '--separateUtils', help='Flag to determine that '
-                        'you do NOT want to to use a shared application utils. ',
-                        action="store_true",
                         required=False)
 
     retAppName = None
@@ -1493,12 +1357,9 @@ def checkArgs():
         retAppName = retEnvList["CUSTOMER_APP_NAME"]
     retCommand = args.command
     retOptions = args.cmdOptions
-    retAppURL = args.appPath
-    retUtilsURL = args.utilsPath
-
-    retSharedUtils = True
-    if args.separateUtils:
-        retSharedUtils = False
+    retAppPath = None
+    if args.appPath:
+        retAppPath = args.appPath
 
     if "WORKSPACE_NAME" in retEnvList:
         retWorkspaceName = retEnvList["WORKSPACE_NAME"]
@@ -1518,16 +1379,13 @@ def checkArgs():
             sys.exit(1)
 
     # if we get here then the
-    return (retAppName, retBaseDir, retWorkspaceName, retCommand, retAppURL,
-            retUtilsURL, retSharedUtils, retEnvList,  retOptions)
+    return (retAppName, retBaseDir, retWorkspaceName, retCommand, retAppPath, retEnvList, retOptions)
 
 
 def main(argv):
-    (appName, baseDir, workspaceName, command, appPath, utilsPath,
-     sharedUtilsFlag, envList, options) = checkArgs()
+    (appName, baseDir, workspaceName, command, appPath, envList, options) = checkArgs()
 
-    customerApp = ManageAppName(appName, baseDir, workspaceName, appPath,
-                                sharedUtilsFlag, utilsPath, envList)
+    customerApp = ManageAppName(appName, baseDir, workspaceName, envList, appPath)
     customerApp.run(command, options)
 
 

--- a/manageApp.py
+++ b/manageApp.py
@@ -831,20 +831,19 @@ class ManageAppName:
         if self.sharedUtilsFlag and theType == "utils":
             # the basePath includes the standard shared repo named
             # directory
-            print("joinWithGit for utils, basePath is: {}").format(basePath)
             if os.path.exists(basePath + "/dcShared-utils"):
                 # then we need to be in that directory to do the pull
                 originalDir = os.getcwd()
                 os.chdir(basePath + '/dcShared-utils')
                 flagToChangeBackToOriginalDir = True
-                print("Cloning: " + theURL)
+                print("Pulling: " + theURL)
+                cloneOrPull = " pull "
+                cloneOrPullString = "pulling"
             else:
                 flagToChangeBackToOriginalDir = True
                 originalDir = os.getcwd()
                 os.chdir(self.baseDir)
-                print("Pulling: " + theURL)
-                cloneOrPull = " pull "
-                cloneOrPullString = "pulling"
+                print("Cloning: " + theURL)
         else:
             print("Cloning: " + theURL)
 

--- a/manageApp.py
+++ b/manageApp.py
@@ -832,19 +832,19 @@ class ManageAppName:
             # the basePath includes the standard shared repo named
             # directory
             print("joinWithGit for utils, basePath is: {}").format(basePath)
-            if os.path.exists(basePath):
+            if os.path.exists(basePath + "/dcShared-utils"):
                 # then we need to be in that directory to do the pull
                 originalDir = os.getcwd()
-                os.chdir(basePath)
+                os.chdir(basePath + '/dcShared-utils')
                 flagToChangeBackToOriginalDir = True
-                print("Pulling: " + theURL)
-                cloneOrPull = " pull "
-                cloneOrPullString = "pulling"
+                print("Cloning: " + theURL)
             else:
                 flagToChangeBackToOriginalDir = True
                 originalDir = os.getcwd()
                 os.chdir(self.baseDir)
-                print("Cloning: " + theURL)
+                print("Pulling: " + theURL)
+                cloneOrPull = " pull "
+                cloneOrPullString = "pulling"
         else:
             print("Cloning: " + theURL)
 

--- a/manageApp.py
+++ b/manageApp.py
@@ -282,8 +282,11 @@ class ManageAppName:
             print(self.getUniqueStackID())
             sys.exit(1)
 
-        if self.sharedUtilsFlag:
-            self.writeToSharedSettings()
+# TODO come back to this when implementing the shared settings
+# during the create app.  This will need to utilize the class
+# SharedSettings
+#        if self.sharedUtilsFlag:
+#            self.writeToSharedSettings()
 
     def parseOptions(self, options):
         """options is string of comma separate key=value pairs. If there is

--- a/manageApp.py
+++ b/manageApp.py
@@ -831,6 +831,7 @@ class ManageAppName:
         if self.sharedUtilsFlag and theType == "utils":
             # the basePath includes the standard shared repo named
             # directory
+            print("joinWithGit for utils, basePath is: {}").format(basePath)
             if os.path.exists(basePath):
                 # then we need to be in that directory to do the pull
                 originalDir = os.getcwd()

--- a/manageApp.py
+++ b/manageApp.py
@@ -36,6 +36,7 @@
 
 # flake8: noqa
 import os
+import fnmatch
 from os.path import expanduser
 import shutil
 import sys
@@ -144,7 +145,7 @@ class ManageAppName:
                     " will assist with correcting this.")
             sys.exit(1)
 
-        # need to get the information from the shared settings about the 
+        # need to get the information from the shared settings about the
         # application VCS (git) URL(s) and the utilities URL.  This was
         # created when the application was created
         self.theSharedSettings = SharedSettings(self.sharedSettingsFile)
@@ -327,7 +328,7 @@ class ManageAppName:
 
         # get the app-utils
         self.joinWithGit(basePath, "utils", self.theSharedSettings.getUtilitiesRepo(self.appName))
-        
+
         # and the environments directory
         envDir = basePath + "/" + self.utilsDirName + "/environments"
         if not os.path.exists(envDir):
@@ -349,8 +350,17 @@ class ManageAppName:
             os.makedirs(generatedEnvDir, 0o755)
             open(generatedEnvDir + "/.keep", 'a').close()
 
-        # TODO need to ensure any keys that are pulled down have the correct
-        # permissions
+        # need to ensure any keys that are pulled down have the correct permissions
+        privateKeyFileList = []
+        keysDir = basePath + '/' + self.utilsDirName + '/keys'
+
+        for root, dirnames, filenames in os.walk(keysDir):
+            for filename in fnmatch.filter(filenames, '*.pem'):
+                privateKeyFileList.append(os.path.join(root, filename))
+
+        # now go through the list and chmod them
+        for keyFile in privateKeyFileList:
+            os.chmod(keyFile, 0400)
 
         print("Completed successfully\n")
 
@@ -708,7 +718,7 @@ class ManageAppName:
             strToWrite = (
                 "# some app env vars specific to the environment\n"
                 "dcHOME=~/" + self.appName + "\n"
-                "dcTempDir=/media/data/tmp\n"                             
+                "dcTempDir=/media/data/tmp\n"
                 "\n#\n"
                 "# Papertrail settings\n"
                 "#\n"

--- a/scripts/sharedsettings.py
+++ b/scripts/sharedsettings.py
@@ -136,7 +136,8 @@ class SharedSettings:
             else:
                 return False
         else:
-            return False
+            # by default we want to create a shared app-utilities
+            return True
     
     def getVCSServiceName(self, app=None):
         """Return the version control system service name for this application."""

--- a/scripts/sharedsettings.py
+++ b/scripts/sharedsettings.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python
+"""Docstring for module."""
+
+import sys
+import argparse
+import json
+from os.path import expanduser
+# ==============================================================================
+__version__ = "0.1"
+
+__copyright__ = "Copyright 2018, devops.center"
+__credits__ = ["Bob Lozano", "Gregg Jensen"]
+__license__ = ' \
+   # Copyright 2014-2018 devops.center llc                                    \
+   #                                                                          \
+   # Licensed under the Apache License, Version 2.0 (the "License");          \
+   # you may not use this file except in compliance with the License.         \
+   # You may obtain a copy of the License at                                  \
+   #                                                                          \
+   #   http://www.apache.org/licenses/LICENSE-2.0                             \
+   #                                                                          \
+   # Unless required by applicable law or agreed to in writing, software      \
+   # distributed under the License is distributed on an "AS IS" BASIS,        \
+   # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. \
+   # See the License for the specific language governing permissions and      \
+   # limitations under the License.                                           \
+   # '
+__status__ = "Development"
+# ==============================================================================
+
+class SharedSettings:
+
+    def __init__(self, fileName):
+        """Construct an instance to utilize the shared settings file."""
+        self.settingsAll = None
+        self.customerInfo = []
+        self.regionInfo = []
+        self.applicationInfo = []
+        self.customerInfoNew = {} 
+        self.applicationInfoNew = {} 
+        self.regionInfoNew = {} 
+        self.updatedCustomerInfo = False
+        self.updatedApplicationInfo = False
+        self.updatedRegionInfo = False
+        self.readSharedSettingsFile(fileName)
+
+    def createCustomerInfo(self, name, vcsServiceName = None, vcsAccountName = None):
+        self.updatedCustomerInfo = True
+        self.customerInfoNew["Name"] = name
+        if vcsServiceName:
+            self.customerInfoNew["VCSServiceName"] = vcsServiceName,
+        if vcsAccountName:
+            self.customerInfoNew["VCSAccountName"] = vcsAccountName
+    
+    def addCustomerVCSInfo(self, vcsServiceName, vcsAccountName):
+        self.updatedCustomerInfo = True
+        self.customerInfoNew["VCSServiceName"] = vcsServiceName
+        self.customerInfoNew["VCSAccountName"] = vcsAccountName
+
+    def getCustomerInfo(self):
+        if "Customer" in self.settingsAll:
+            return self.customerInfo
+
+    def getCustomerName(self):
+        if "Customer" in self.settingsAll:
+            return self.customerInfo["Name"]
+
+    def getCustomerVCSServiceName(self):
+        if "Customer" in self.settingsAll:
+            if "VCSServiceName" in self.customerInfo:
+                return self.customerInfo["VCSServiceName"]
+            else:
+                return None
+
+    def getCustomerVCSAccountName(self):
+        if "Customer" in self.settingsAll:
+            if "VCSAccountName" in self.customerInfo:
+                return self.customerInfo["VCSAccountName"]
+            else:
+                return None
+
+    def listApplications(self):
+        """Return the list customer's application names."""
+        retArray = []
+        for item in self.applicationInfo:
+            retArray.append(item['Name'])
+        return retArray
+    
+    def getApplicationInfo(self, app):
+        """Return all the information associated with the specified application."""
+        appInfo = None
+        for item in self.applicationInfo:
+            if item["Name"] == app:
+                appInfo = item
+        return appInfo
+    
+    def addApplicationInfo(self, name,  utilsRepo, appRepoList, vcsServiceName = None, vcsAccountName = None):
+        """Adds the items that make up the application info."""
+        self.updatedApplicationInfo = True
+        self.applicationInfoNew["Name"] = name
+        self.applicationInfoNew["UTILS_REPO"] = utilsRepo
+        if isinstance(appRepoList, basestring):
+            # make sure it is an array
+            self.applicationInfoNew["APP_REPO"] = [ appRepoList ]
+        else:
+            self.applicationInfoNew["APP_REPO"] = appRepoList
+        if "Shared" in utilsRepo: 
+            self.applicationInfoNew["shared"] = "true"
+        if vcsServiceName:
+            self.applicationInfoNew["VCSServiceName"] = vcsServiceName,
+        if vcsAccountName:
+            self.applicationInfoNew["VCSAccountName"] = vcsAccountName
+
+    def getApplicationRepoList(self, app):
+        """Return the list of application repository URLs for a given application."""
+        anItem = self.getApplicationInfo(app)
+        if anItem:
+            return anItem["APP_REPO"]
+        else:
+            return None
+
+    def getUtilitiesRepo(self, app):
+        """Return the utilities repository URL for a given application."""
+        anItem = self.getApplicationInfo(app)
+        if anItem:
+            return anItem["UTILS_REPO"]
+        else:
+            return None
+    
+    def isShared(self, app):
+        """Return where this app is using shared utilizies."""
+        anItem = self.getApplicationInfo(app)
+        if anItem["shared"] == "true":
+            return True
+        else:
+            return False
+    
+    def getVCSServiceName(self, app=None):
+        """Return the version control system service name for this application."""
+        if app:
+            anItem = self.getApplicationInfo(app)
+            if anItem:
+                # NOTE: the service name can be defined in the Customer info section so
+                # it could be possible that it is not be duplicated in the app section
+                if "VCSServiceName" in anItem:
+                    return anItem["VCSServiceName"]
+                else:
+                    return None
+        else:
+            if "VCSServiceName" in self.customerInfo:
+                return self.customerInfo["VCSServiceName"]
+            else:
+                return None
+
+    def getVCSAccountName(self, app=None):
+        """Return the version control system accountname for this application."""
+        anItem = self.getApplicationInfo(app)
+        if app:
+            if anItem:
+                # NOTE: the service name can be defined in the Customer info section so
+                # it could be possible that it is not be duplicated in the app section
+                if "VCSAccountName" in anItem:
+                    return anItem["VCSAccountName"]
+                else:
+                    return None
+        else:
+            if "VCSAccountName" in self.customerInfo:
+                return self.customerInfo["VCSAccountName"]
+            else:
+                return None
+
+    def readSharedSettingsFile(self, fileName):
+        """Read in the shared settings file."""
+        try:
+            with open(expanduser(fileName)) as data_file:
+                self.settingsAll = json.load(data_file)
+                if 'Customer' in self.settingsAll:
+                    self.customerInfo = self.settingsAll['Customer']
+                if 'Applications' in self.settingsAll:
+                    self.applicationInfo = self.settingsAll['Applications']
+                if 'Regions' in self.settingsAll:
+                    self.regionInfo = self.settingsAll['Regions']
+        except IOError as e:
+            print("ERROR trying to read the shared settings file")
+            print("Shared dcConfig settings file error: {}".format(e))
+            sys.exit(1)
+        
+    def checkCustomerInfo(self):
+        """Check to see what has changed and make a merged section."""
+        tmpCusInfo = {}
+        # Name
+        tmpCusInfo["Name"] = self.customerInfoNew["Name"] if self.customerInfoNew["Name"] != self.customerInfo["Name"] else  self.customerInfo["Name"]
+
+        # VCSServiceName
+        tmpCusInfo["VCSServiceName"] = self.customerInfoNew["VCSServiceName"] if self.customerInfoNew["VCSServiceName"] != self.customerInfo["VCSServiceName"] else self.customerInfo["VCSServiceName"]
+
+        # VCSAccountName
+        tmpCusInfo["VCSAccountName"] = self.customerInfoNew["VCSAccountName"] if self.customerInfoNew["VCSAccountName"] != self.customerInfo["VCSAccountName"] else self.customerInfo["VCSAccountName"]
+        
+        self.writeSettingsAll['Customer'] = tmpCusInfo
+
+    def checkApplicationInfo(self):
+        """Check to see what has changed and make a merged section."""
+        tmpAppList = []
+        for anApp in self.applicationInfo:
+            if self.applicationInfoNew["Name"] != anApp["Name"]:
+                tmpAppList.append(anApp)
+
+        tmpAppInfo = {}
+        # Name
+        tmpAppInfo["Name"] = self.applicationInfoNew["Name"] 
+
+        # VCSServiceName
+        if "VCSServiceName" in self.applicationInfoNew:
+            tmpAppInfo["VCSServiceName"] = self.applicationInfoNew["VCSServiceName"] 
+
+        # VCSAccountName
+        if "VCSAccountName" in self.applicationInfoNew:
+            tmpAppInfo["VCSAccountName"] = self.applicationInfoNew["VCSAccountName"]
+
+        # shared
+        tmpAppInfo["shared"] = self.applicationInfoNew["shared"]
+
+        # UTILS_REPO
+        tmpAppInfo["UTILS_REPO"] = self.applicationInfoNew["UTILS_REPO"]
+
+        # APP_REPO
+        tmpAppInfo["APP_REPO"] = self.applicationInfoNew["APP_REPO"]
+
+        tmpAppList.append(tmpAppInfo)
+
+        self.writeSettingsAll['Applications'] = tmpAppList
+
+    def checkRegionInfo(self):
+        """Check to see what has changed and make a merged section."""
+        if self.regionInfo:
+            self.writeSettingsAll['Regions'] = self.regionInfo
+
+    def writeSharedSettingsFile(self, fileName):
+        """Write the shared settings file with any new updated information."""
+        if self.updatedCustomerInfo or self.updatedApplicationInfo or self.updatedRegionInfo:
+            # now check each section and merge into a new writeable data structure
+            self.writeSettingsAll = {}
+            self.checkCustomerInfo()
+            self.checkApplicationInfo()
+            self.checkRegionInfo()
+            
+            # now convert the structure to json and write the file
+            with open(expanduser(fileName), 'w') as outfile:
+                json.dump(self.writeSettingsAll, outfile, indent = 2, ensure_ascii = False)
+
+        else:
+            print("Nothing updated, not writing.")
+
+
+def checkArgs():
+    """Check the command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=('comment'))
+    parser.parse_args()
+
+def testSharedSettings(theSettings):
+    """Get the values from the settings file."""
+    print("Customer info: {}").format(theSettings.getCustomerInfo())
+    print("Applications: {}").format(theSettings.listApplications())
+    print("Customer level VCS service: {}").format(theSettings.getVCSServiceName())
+    print("Customer level VCS account: {}").format(theSettings.getVCSAccountName())
+    
+    for theApp in theSettings.listApplications():
+        print("VCS service:[{}] {}").format(theApp, theSettings.getVCSServiceName(theApp))
+        print("VCS account:[{}] {}").format(theApp, theSettings.getVCSAccountName(theApp))
+        if theSettings.isShared(theApp):
+            print("Shared utilities found at {}").format(theSettings.getUtilitiesRepo(theApp))
+        else:
+            print("NOT using the shared utilities facility.")
+
+        print("The list of application repos is:")
+        for item in theSettings.getApplicationRepoList(theApp):
+            print("\t{}").format(item)
+
+
+def main(argv):
+    """Main code goes here."""
+    checkArgs()
+
+    commonSharedSettingsFile = "~/devops/testscripts/python-stuff/shared-settings/settings.json"
+    theSettings = SharedSettings(commonSharedSettingsFile)
+    testSharedSettings(theSettings)
+
+# If you want to see how to add new information
+#    outputSettingsFile = "~/devops/testscripts/python-stuff/shared-settings/settings-new.json"
+#    print("Now create a new customer info section")
+#    theSettings.createCustomerInfo("clEAR")
+#    theSettings.addCustomerVCSInfo("newGitService", "clearsys")
+#
+#    print("Now create an all new set of application information")
+#    theSettings.addApplicationInfo("moonride", "git@github.com:quasarsys/dcSharedUtils.git", 
+#                                   "git@github.com:quasarsys/moonride")
+#
+#    theSettings.writeSharedSettingsFile(outputSettingsFile)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+

--- a/scripts/sharedsettings.py
+++ b/scripts/sharedsettings.py
@@ -130,8 +130,11 @@ class SharedSettings:
     def isShared(self, app):
         """Return where this app is using shared utilizies."""
         anItem = self.getApplicationInfo(app)
-        if anItem["shared"] == "true":
-            return True
+        if anItem:
+            if anItem["shared"] == "true":
+                return True
+            else:
+                return False
         else:
             return False
     

--- a/switchWorkspace.sh
+++ b/switchWorkspace.sh
@@ -139,4 +139,7 @@ sed -i -e "s/CURRENT_WORKSPACE=.*/CURRENT_WORKSPACE=${NEW_WORKSPACE_NAME}/" "${C
 newCustomerName=${FILE_EXISTS##*/}
 sed -i -e "s/CUSTOMER_NAME=.*/CUSTOMER_NAME=${newCustomerName,,}/" ~/.dcConfig/settings
 sed -i -e "s/PROFILE=.*/PROFILE=${newCustomerName,,}/" ~/.dcConfig/settings
+# this one is if there are quotes around the directory and if not it will fail silently
 sed -i -e "/dcCOMMON_SHARED_DIR/s/=\"\(.*\/\).*\"/=\"\1${newCustomerName,,}\"/" ~/.dcConfig/settings
+# and this one is for when there are no quotes
+sed -i -e "/dcCOMMON_SHARED_DIR/s/=\(.*\/\).*\"/=\"\1${newCustomerName,,}/" ~/.dcConfig/settings

--- a/switchWorkspace.sh
+++ b/switchWorkspace.sh
@@ -142,4 +142,4 @@ sed -i -e "s/PROFILE=.*/PROFILE=${newCustomerName,,}/" ~/.dcConfig/settings
 # this one is if there are quotes around the directory and if not it will fail silently
 sed -i -e "/dcCOMMON_SHARED_DIR/s/=\"\(.*\/\).*\"/=\"\1${newCustomerName,,}\"/" ~/.dcConfig/settings
 # and this one is for when there are no quotes
-sed -i -e "/dcCOMMON_SHARED_DIR/s/=\(.*\/\).*\"/=\"\1${newCustomerName,,}/" ~/.dcConfig/settings
+sed -i -e "/dcCOMMON_SHARED_DIR/s/=\(.*\/\).*/=\1${newCustomerName,,}/" ~/.dcConfig/settings

--- a/switchWorkspace.sh
+++ b/switchWorkspace.sh
@@ -140,7 +140,10 @@ newCustomerName=${FILE_EXISTS##*/}
 sed -i -e "s/CUSTOMER_NAME=.*/CUSTOMER_NAME=${newCustomerName,,}/" ~/.dcConfig/settings
 sed -i -e "s/PROFILE=.*/PROFILE=${newCustomerName,,}/" ~/.dcConfig/settings
 sed -i -e "s/CURRENT_WORKSPACE=.*/CURRENT_WORKSPACE=${newCustomerName,,}/" ~/.dcConfig/settings
-# this one is if there are quotes around the directory and if not it will fail silently
-sed -i -e "/dcCOMMON_SHARED_DIR/s/=\"\(.*\/\).*\"/=\"\1${newCustomerName,,}\"/" ~/.dcConfig/settings
-# and this one is for when there are no quotes
-sed -i -e "/dcCOMMON_SHARED_DIR/s/=\(.*\/\).*/=\1${newCustomerName,,}/" ~/.dcConfig/settings
+if [[ $(grep -c "dcCOMMON_SHARED_DIR=\"" ~/.dcConfig/settings) -eq 0 ]]; then
+    # and this one is for when there are no quotes
+    sed -i -e "/dcCOMMON_SHARED_DIR/s/=\(.*\/\).*/=\1${newCustomerName,,}/" ~/.dcConfig/settings
+else
+    # this one is if there are quotes around the directory
+    sed -i -e "/dcCOMMON_SHARED_DIR/s/=\"\(.*\/\).*\"/=\"\1${newCustomerName,,}\"/" ~/.dcConfig/settings
+fi

--- a/switchWorkspace.sh
+++ b/switchWorkspace.sh
@@ -139,6 +139,7 @@ sed -i -e "s/CURRENT_WORKSPACE=.*/CURRENT_WORKSPACE=${NEW_WORKSPACE_NAME}/" "${C
 newCustomerName=${FILE_EXISTS##*/}
 sed -i -e "s/CUSTOMER_NAME=.*/CUSTOMER_NAME=${newCustomerName,,}/" ~/.dcConfig/settings
 sed -i -e "s/PROFILE=.*/PROFILE=${newCustomerName,,}/" ~/.dcConfig/settings
+sed -i -e "s/CURRENT_WORKSPACE=.*/CURRENT_WORKSPACE=${newCustomerName,,}/" ~/.dcConfig/settings
 # this one is if there are quotes around the directory and if not it will fail silently
 sed -i -e "/dcCOMMON_SHARED_DIR/s/=\"\(.*\/\).*\"/=\"\1${newCustomerName,,}\"/" ~/.dcConfig/settings
 # and this one is for when there are no quotes


### PR DESCRIPTION
This set of changes provides manageApp.py the ability to read the shared settings.json file to get the particulars of the repositories for the application and the application utilities.  Using this, the user that runs manageApp.py to join the development of an application will not have to know any of source repositories; rather, they just need to provide the application name and possibly the workspace name if it is used, to join the development of an application.  Also, introduced is the new script addWorkspace.sh to create a new workspace as a separate action prior to running manageApp.py.  

This complements switchWorkspace.sh.

Note that while most source repositories are likely to use a git-compatible VCS (version control system), these scripts do not assume git compatibility per se.